### PR TITLE
Added more benchmarks

### DIFF
--- a/src/main/java/me/antonle/jmh/PrimitiveCalcBenchmark.java
+++ b/src/main/java/me/antonle/jmh/PrimitiveCalcBenchmark.java
@@ -109,6 +109,47 @@ public class PrimitiveCalcBenchmark {
         System.out.println(res);
     }
 
+    @Benchmark
+    public void boxedPrimitiveWithoutStream(BoxState state) {
+        int res = 0;
+        for (Integer t : state.list) {
+            Integer x = t;
+            x *= 2;
+            x -= 12;
+            x *= x;
+            res += x;
+        }
+        System.out.println(res);
+    }
+
+    @Benchmark
+    public void boxedPrimitiveMathSingleCall(BoxState state) {
+        int res = state.list.stream()
+            .map((x) -> {
+                x = x * 2;
+                x -= 12;
+                x *= x;
+                return x;
+            })
+            .mapToInt(x -> x)
+            .sum();
+
+        System.out.println(res);
+    }
+
+    @Benchmark
+    public void unboxedPrimitiveMathSingleCall(UnboxedState state) {
+        int res = Arrays.stream(state.list)
+            .map((x) -> {
+                x = x * 2;
+                x -= 12;
+                x *= x;
+                return x;
+            })
+            .sum();
+
+        System.out.println(res);
+    }
 /*
 Benchmark                                              Mode  Cnt   Score   Error  Units
 PrimitiveCalcBenchmark.boxedPrimitiveMath             thrpt   25   0.677 ± 0.009  ops/s


### PR DESCRIPTION
Will update with my numbers soon. Couple of notes:

1. I tested for array size of 10 000 000, but conclusions should still hold

2. My expected numbers are: 
- Boxed Primitive stream w/ Multiple lambdas ~ 6 ops/s
- Boxed Primitive stream w/ Single Lambda ~ 11 ops/s
- Boxed Primitive without stream ~ 16 ops / s
- Unboxed Primitive stream w/ Multiple lambdas ~ 11 ops/s
- Unboxed Primitive stream w/ Single lambda ~ 270 ops/s
- Unboxed Primitive without stream ~ 400 ops/s

- Boxed iteration + unboxed operations (see point #3) ~ 60 ops/s

3. Note, that if in `boxedPrimitiveWithoutStream` replace `Integer x = ...` to `int x = ...`, this given 5x speedup. 

Overall I don't know what exactly causes `unboxedPrimitiveMath` to be _that_ slow, but my guess would be: 
1. Alot of overhead on InvokeDynamic when dealing with lambdas -- looked into bytecode
2. Alot of cache misses/underutilization, due to passing variable between lambdas 
Either that, or some imblicit boxing going under the hood

Fun fact: Boxed w/ single lambda is almost the same as unboxed w/ multiple lambdas